### PR TITLE
WIP for Multi-*** selection widgets

### DIFF
--- a/Source/SVWidgetsLib/FilterParameterWidgets/MultiDataContainerSelectionWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/MultiDataContainerSelectionWidget.h
@@ -63,6 +63,12 @@ class SVWidgetsLib_EXPORT MultiDataContainerSelectionWidget : public FilterParam
 {
   Q_OBJECT
 
+  MultiDataContainerSelectionFilterParameter* m_FilterParameter;
+
+  static void syncItems(QListWidget*, const QStringList&, QStringList&);
+  static void moveItems(const QList<QListWidgetItem*>&, QListWidget*, QListWidget*);
+  void validateDataContainerNames(const QListWidget*, const QList<QString>&);
+
 public:
   /**
    * @brief Constructor
@@ -70,7 +76,7 @@ public:
    * @param filter The instance of the filter that this parameter is a part of
    * @param parent The parent QWidget for this Widget
    */
-  MultiDataContainerSelectionWidget(FilterParameter* parameter, AbstractFilter* filter = nullptr, QWidget* parent = nullptr);
+  MultiDataContainerSelectionWidget(FilterParameter*, AbstractFilter* filter = nullptr, QWidget* parent = nullptr);
 
   ~MultiDataContainerSelectionWidget() override;
 
@@ -78,6 +84,10 @@ public:
    * @brief This method does additional GUI widget connections
    */
   void setupGui() override;
+  MultiDataContainerSelectionWidget(const MultiDataContainerSelectionWidget&) = delete;            // Copy Constructor Not Implemented
+  MultiDataContainerSelectionWidget(MultiDataContainerSelectionWidget&&) = delete;                 // Move Constructor Not Implemented
+  MultiDataContainerSelectionWidget& operator=(const MultiDataContainerSelectionWidget&) = delete; // Copy Assignment Not Implemented
+  MultiDataContainerSelectionWidget& operator=(MultiDataContainerSelectionWidget&&) = delete;      // Move Assignment Not Implemented
 
 public slots:
   void beforePreflight();
@@ -85,17 +95,7 @@ public slots:
   void filterNeedsInputParameters(AbstractFilter* filter);
 
 protected slots:
-  void updateDataContainerName(const QString& propertyName, const DataArrayPath::RenameType& renamePath);
-
-private:
-  MultiDataContainerSelectionFilterParameter* m_FilterParameter;
-
-  static void syncItems(QListWidget*, const QStringList&, QStringList&);
-  static void validateDataContainerNames(const SVListWidget*, const QList<QString>&);
-
-public:
-  MultiDataContainerSelectionWidget(const MultiDataContainerSelectionWidget&) = delete;            // Copy Constructor Not Implemented
-  MultiDataContainerSelectionWidget(MultiDataContainerSelectionWidget&&) = delete;                 // Move Constructor Not Implemented
-  MultiDataContainerSelectionWidget& operator=(const MultiDataContainerSelectionWidget&) = delete; // Copy Assignment Not Implemented
-  MultiDataContainerSelectionWidget& operator=(MultiDataContainerSelectionWidget&&) = delete;      // Move Assignment Not Implemented
+  void updateDataContainerName(const QString&, const DataArrayPath::RenameType&);
+  void on_availableDataContainers_itemDoubleClicked(QListWidgetItem*);
+  void on_selectedDataContainers_itemDoubleClicked(QListWidgetItem*);
 };

--- a/Source/SVWidgetsLib/FilterParameterWidgets/MultiDataContainerSelectionWidget.h
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/MultiDataContainerSelectionWidget.h
@@ -37,6 +37,7 @@
 #include <QtCore/QObject>
 #include <QtCore/QPointer>
 #include <QtWidgets/QWidget>
+#include <QStringListModel>
 
 #include "SVWidgetsLib/QtSupport/QtSFaderWidget.h"
 
@@ -62,12 +63,18 @@ class QSignalMapper;
 class SVWidgetsLib_EXPORT MultiDataContainerSelectionWidget : public FilterParameterWidget, private Ui::MultiDataContainerSelectionWidget
 {
   Q_OBJECT
+  QStringListModel m_availableDCs{};
 
   MultiDataContainerSelectionFilterParameter* m_FilterParameter;
+  void validateDataContainerNames(const QList<QString>&);
 
-  static void syncItems(QListWidget*, const QStringList&, QStringList&);
-  static void moveItems(const QList<QListWidgetItem*>&, QListWidget*, QListWidget*);
-  void validateDataContainerNames(const QListWidget*, const QList<QString>&);
+protected slots:
+  void updateDataContainerName(const QString&, const DataArrayPath::RenameType&);
+
+public slots:
+  void beforePreflight();
+  void afterPreflight();
+  void filterNeedsInputParameters(AbstractFilter* filter);
 
 public:
   /**
@@ -77,25 +84,13 @@ public:
    * @param parent The parent QWidget for this Widget
    */
   MultiDataContainerSelectionWidget(FilterParameter*, AbstractFilter* filter = nullptr, QWidget* parent = nullptr);
-
+  MultiDataContainerSelectionWidget(const MultiDataContainerSelectionWidget&) = delete;            // Copy Constructor Not Implemented
+  MultiDataContainerSelectionWidget(MultiDataContainerSelectionWidget&&) = delete;                 // Move Constructor Not Implemented
+  MultiDataContainerSelectionWidget& operator=(const MultiDataContainerSelectionWidget&) = delete; // Copy Assignment Not Implemented
   ~MultiDataContainerSelectionWidget() override;
 
   /**
    * @brief This method does additional GUI widget connections
    */
   void setupGui() override;
-  MultiDataContainerSelectionWidget(const MultiDataContainerSelectionWidget&) = delete;            // Copy Constructor Not Implemented
-  MultiDataContainerSelectionWidget(MultiDataContainerSelectionWidget&&) = delete;                 // Move Constructor Not Implemented
-  MultiDataContainerSelectionWidget& operator=(const MultiDataContainerSelectionWidget&) = delete; // Copy Assignment Not Implemented
-  MultiDataContainerSelectionWidget& operator=(MultiDataContainerSelectionWidget&&) = delete;      // Move Assignment Not Implemented
-
-public slots:
-  void beforePreflight();
-  void afterPreflight();
-  void filterNeedsInputParameters(AbstractFilter* filter);
-
-protected slots:
-  void updateDataContainerName(const QString&, const DataArrayPath::RenameType&);
-  void on_availableDataContainers_itemDoubleClicked(QListWidgetItem*);
-  void on_selectedDataContainers_itemDoubleClicked(QListWidgetItem*);
 };

--- a/Source/SVWidgetsLib/FilterParameterWidgets/UI_Files/MultiDataContainerSelectionWidget.ui
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/UI_Files/MultiDataContainerSelectionWidget.ui
@@ -54,7 +54,7 @@
           </font>
          </property>
          <property name="text">
-          <string>Available Data Containers</string>
+          <string>Select Your Data Containers</string>
          </property>
          <property name="alignment">
           <set>Qt::AlignCenter</set>
@@ -62,75 +62,9 @@
         </widget>
        </item>
        <item>
-        <widget class="SVListWidget" name="availableDataContainers">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="sizeAdjustPolicy">
-          <enum>QAbstractScrollArea::AdjustIgnored</enum>
-         </property>
-         <property name="editTriggers">
-          <set>QAbstractItemView::NoEditTriggers</set>
-         </property>
-         <property name="dragEnabled">
-          <bool>true</bool>
-         </property>
-         <property name="dragDropMode">
-          <enum>QAbstractItemView::DragDrop</enum>
-         </property>
-         <property name="defaultDropAction">
-          <enum>Qt::MoveAction</enum>
-         </property>
+        <widget class="SVListView" name="dataContainers">
          <property name="selectionMode">
           <enum>QAbstractItemView::ExtendedSelection</enum>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </item>
-     <item>
-      <layout class="QVBoxLayout" name="verticalLayout">
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <item>
-        <widget class="QLabel" name="label_2">
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Selected Data Containers</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="SVListWidget" name="selectedDataContainers">
-         <property name="editTriggers">
-          <set>QAbstractItemView::NoEditTriggers</set>
-         </property>
-         <property name="dragEnabled">
-          <bool>true</bool>
-         </property>
-         <property name="dragDropMode">
-          <enum>QAbstractItemView::DragDrop</enum>
-         </property>
-         <property name="defaultDropAction">
-          <enum>Qt::MoveAction</enum>
-         </property>
-         <property name="selectionMode">
-          <enum>QAbstractItemView::ExtendedSelection</enum>
-         </property>
-         <property name="sortingEnabled">
-          <bool>false</bool>
          </property>
         </widget>
        </item>
@@ -142,8 +76,8 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>SVListWidget</class>
-   <extends>QListWidget</extends>
+   <class>SVListView</class>
+   <extends>QListView</extends>
    <header location="global">SVControlWidgets.h</header>
   </customwidget>
  </customwidgets>

--- a/Source/SVWidgetsLib/FilterParameterWidgets/UI_Files/MultiDataContainerSelectionWidget.ui
+++ b/Source/SVWidgetsLib/FilterParameterWidgets/UI_Files/MultiDataContainerSelectionWidget.ui
@@ -62,7 +62,7 @@
         </widget>
        </item>
        <item>
-        <widget class="SVListWidget" name="dataContainersSelectWidget">
+        <widget class="SVListWidget" name="availableDataContainers">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
            <horstretch>0</horstretch>
@@ -113,7 +113,7 @@
         </widget>
        </item>
        <item>
-        <widget class="SVListWidget" name="dataContainersOrderWidget">
+        <widget class="SVListWidget" name="selectedDataContainers">
          <property name="editTriggers">
           <set>QAbstractItemView::NoEditTriggers</set>
          </property>


### PR DESCRIPTION
Work done on MultiDataContainerSelection widget includes simplifying down to single list, using currently selected items for setting the filter parameter property instead. It also bases the widget class on a ListView instead of a ListWidget, which relies on setting up a QAbstractItemModel (specifically the QStringListModel), making it easier to track and update changes with much less custom code.

This could then be extended to the other Multi-*** select widgets as well.